### PR TITLE
Fix contributors link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Disclosure Policies, see [SECURITY.md](SECURITY.md).
 
 ## Authors and Maintainers
 
-A full list of contributors can be found on [https://github.cms.gov/dsacms/drive2gource/graphs/contributors](https://github.cms.gov/dsacms/drive2gource/graphs/contributors).
+A full list of contributors can be found on https://github.com/CMSgov/drive2gource/graphs/contributors.
 
 ## Public domain
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## readme: fix contributors link 

## Problem

I happened to notice that the contributors link in the README still pointed to the internal GitHub.

## Solution

It now points to the current repository.